### PR TITLE
Fix templating

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webformula/pax-core",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "PAX pages and components tool set. Build, render, and serve web-pages and web-components",
   "main": "index.js",
   "type": "module",

--- a/src/buildEntry.js
+++ b/src/buildEntry.js
@@ -95,12 +95,10 @@ async function getTemplate(content, pagesFolder, rootFolder, fullPath) {
   if (match && match.groups && match.groups.content) {
     if (match.groups.content.includes('.html')) {
       const pageTemplatePath = match.groups.content.replace('return', '').replace(';', '').replace(/\'/g, '').replace(/"/g, '').trim();
-      const pageClassDir = path.dirname(fullPath);
-      const templatePath = path.join(pageClassDir, pageTemplatePath);
       try {
         return [
-          templatePath.replace(`${rootFolder}/`, ''),
-          (await readFileAsync(templatePath)).toString()
+          pageTemplatePath,
+          (await readFileAsync(`${rootFolder}/${pageTemplatePath}`)).toString()
         ];
       } catch (e) {
         console.error(e);

--- a/src/client/Page.js
+++ b/src/client/Page.js
@@ -3,7 +3,7 @@ export default class Page {
     this._rendered = false;
     this.global = typeof globalThis !== 'undefined' ? globalThis : window;
 
-    this._filePath = this._getCallerFilePath();
+    // this._filePath = this._getCallerFilePath();
   }
 
   // called once page is rendered
@@ -59,17 +59,14 @@ export default class Page {
     const isUrl = template.match(/.html$/);
 
     if (isUrl) {
-      const possiblePath = new URL(template, this._filePath).pathname;
-
       // template from built template file
-      if (window._templates && (window._templates[possiblePath] || window._templates[possiblePath.replace(/^\/+/, '')])) {
-        this._templateMethod = new Function(`return \`${window._templates[possiblePath] || window._templates[possiblePath.replace(/^\/+/, '')]}\`;`);
+      if (window._templates && (window._templates[template] || window._templates[template.replace(/^\/+/, '')])) {
+        this._templateMethod = new Function(`return \`${window._templates[template] || window._templates[template.replace(/^\/+/, '')]}\`;`);
 
       // load template url
       } else {
         // this._filePath is generated in the constructor
-        const fileUrl = new URL(template, this._filePath);
-        const response = await fetch(fileUrl);
+        const response = await fetch(template);
         const str = await response.text();
         // allow javascript template string syntax in external html file ( ${things} )
         this._templateMethod = new Function(`return \`${str}\`;`);


### PR DESCRIPTION
Remove the ability to use relative page paths. Paths should be specified from the root src folder.
The method i was using to determine the path dynamically in the browser was not supported in mobile chrome and i had to ditch it. I have a couple more ideas on how to handle this but for now i am just remove the ability for relative paths.

Example:
```
templatePath = 'pages/one/page.html';

repoFolder
  - src
     - pages
        - one
           - page.html
```